### PR TITLE
ci: avoid tag-push failure when tag already exists

### DIFF
--- a/.github/workflows/push-docker-hub.yml
+++ b/.github/workflows/push-docker-hub.yml
@@ -66,13 +66,64 @@ jobs:
             xhenxhe/dailynotes:latest
             xhenxhe/dailynotes:${{ steps.version.outputs.version }}
 
-      - name: Create and push git tag
+      - name: Create and push unique git tag (recompute & retry)
+        id: tag
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$VERSION" -m "Release $VERSION"
-          git push origin "$VERSION"
+
+          # Try a few times in case of concurrent runners creating tags at the same time
+          MAX_ATTEMPTS=5
+          attempt=1
+          while [ $attempt -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $attempt/$MAX_ATTEMPTS to create a unique tag..."
+
+            # Ensure we have up-to-date remote tags
+            git fetch --tags --prune origin
+
+            # Compute today's base and next available build number from the current tags
+            TODAY=$(date -u +%Y.%m.%d)
+            LATEST_BUILD=$(git tag --list "${TODAY}-*" | sed "s/${TODAY}-//" | sort -n | tail -1 || true)
+
+            if [ -z "$LATEST_BUILD" ]; then
+              BUILD_NUM="00"
+            else
+              NEXT_NUM=$((10#$LATEST_BUILD + 1))
+              BUILD_NUM=$(printf "%02d" "$NEXT_NUM")
+            fi
+
+            VERSION="${TODAY}-${BUILD_NUM}"
+            echo "Computed version: $VERSION"
+
+            # Check remote and local for existence
+            if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null 2>&1 || \
+               git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+              echo "Tag $VERSION already exists, will try again to compute a new one."
+              attempt=$((attempt+1))
+              # Small backoff to reduce contention
+              sleep $((attempt * 2))
+              continue
+            fi
+
+            # Create and push tag (do NOT force)
+            git tag -a "$VERSION" -m "Release $VERSION"
+            if git push origin "$VERSION"; then
+              echo "Successfully pushed tag $VERSION"
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+              exit 0
+            else
+              echo "Push failed for $VERSION (maybe tag created concurrently). Removing local tag and retrying."
+              git tag -d "$VERSION" || true
+              attempt=$((attempt+1))
+              sleep $((attempt * 2))
+            fi
+          done
+
+          echo "Failed to create a unique tag after $MAX_ATTEMPTS attempts; skipping tag creation to avoid failing the workflow."
+          # Write output so downstream steps know tagging was skipped
+          echo "version=skipped" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v4


### PR DESCRIPTION
## Summary

Fixes a race condition in the Docker Hub push workflow where concurrent runs would calculate the same version tag, causing subsequent runs to fail with:

```
! [rejected] 2025.12.11-12 -> 2025.12.11-12 (already exists)
error: failed to push some refs to 'https://github.com/djedi/DailyNotes'
hint: Updates were rejected because the tag already exists in the remote.
```

**Failing job:** https://github.com/djedi/DailyNotes/actions/runs/20149059339/job/57837228889

## The Problem

The original workflow:
1. Calculates version tag early in the run (step `version`)
2. Builds and pushes Docker image (takes several minutes)
3. Creates and pushes the git tag

If two workflow runs start close together, they both calculate the same tag (e.g., `2025.12.11-12`). The first run succeeds, but the second fails when trying to push the already-existing tag.

## The Fix

Replace the simple tag creation step with a robust script that:
- **Recomputes** the version tag immediately before pushing (not relying on the early calculation)
- **Checks** both local and remote for existing tags before attempting creation
- **Retries** up to 5 times with exponential backoff if a race condition is detected
- **Skips gracefully** instead of failing the workflow if no unique tag can be created after all attempts

## Trade-offs

| Approach | Pros | Cons |
|----------|------|------|
| Skip tagging on conflict | Docker images still get pushed; workflow doesn't fail | Some builds may not get a corresponding git tag |
| Force push tags | Always succeeds | Could overwrite important tags (dangerous) |
| Fail the workflow | Explicit about conflicts | Wastes build time; requires manual retry |

This PR chooses **skip gracefully** because:
- The Docker image is already pushed successfully at this point
- The `latest` tag is always updated regardless
- A missing git tag for one build is less disruptive than a failed workflow
- The step outputs `version=skipped` so downstream steps can detect this if needed

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Trigger concurrent workflow runs to confirm race condition handling
- [ ] Verify successful runs still create and push tags correctly